### PR TITLE
sinntp: use env to choose the right python interpreter

### DIFF
--- a/sinntp
+++ b/sinntp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # encoding=UTF-8
 
 # Copyright © 2008-2015

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # encoding=UTF-8
 
 # Copyright © 2011-2012


### PR DESCRIPTION
Hey Jakub and Piotr,

this small patch fixes an issue on my box where the default python interpreter is set to python3.

Cheers
  Ralf
